### PR TITLE
WP7 hardening: random-page-redirect-for-wordpress (v1.6148.2110)

### DIFF
--- a/abilities.php
+++ b/abilities.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * WP 7 Abilities API registration for Random Page Redirect for WordPress.
+ *
+ * Exposes the plugin's random-published-post selection as a discoverable,
+ * REST/AI-invokable ability. The ability returns URL data only — it never
+ * performs the HTTP redirect that the /random endpoint does.
+ *
+ * @package Random_Page_Redirect_For_WordPress
+ * @since   1.6148
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return; // Abilities API unavailable (WordPress < 6.9).
+		}
+
+		wp_register_ability(
+			'random-page-redirect/get-random-url',
+			array(
+				'label'               => __( 'Get Random Page URL', 'random-page-redirect-for-wordpress' ),
+				'description'         => __( 'Returns one or more random published posts as {id, url} pairs. Use this to surface a "surprise me" link or seed discovery without performing a redirect. Each call may return a different selection.', 'random-page-redirect-for-wordpress' ),
+				'category'            => 'site',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_type' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional: a single public post type to draw from. Defaults to "post". Ignored if not a registered, publicly-queryable post type.', 'random-page-redirect-for-wordpress' ),
+						),
+						'count'     => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 20,
+							'description' => __( 'Optional: how many random URLs to return (1-20). Defaults to 1.', 'random-page-redirect-for-wordpress' ),
+						),
+					),
+					'additionalProperties' => false,
+					'default'              => array(),
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'required'             => array( 'items' ),
+					'properties'           => array(
+						'items' => array(
+							'type'        => 'array',
+							'description' => __( 'The selected random posts. Empty when no eligible published post exists.', 'random-page-redirect-for-wordpress' ),
+							'items'       => array(
+								'type'                 => 'object',
+								'required'             => array( 'id', 'url' ),
+								'properties'           => array(
+									'id'  => array(
+										'type'        => 'integer',
+										'description' => __( 'The post ID.', 'random-page-redirect-for-wordpress' ),
+									),
+									'url' => array(
+										'type'        => 'string',
+										'description' => __( 'The permalink of the selected post.', 'random-page-redirect-for-wordpress' ),
+									),
+								),
+								'additionalProperties' => false,
+							),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => static function ( $input = array() ) {
+					$input = is_array( $input ) ? $input : array();
+
+					$count = isset( $input['count'] ) ? (int) $input['count'] : 1;
+					$count = max( 1, min( 20, $count ) );
+
+					$post_types = null;
+					if ( isset( $input['post_type'] ) && '' !== $input['post_type'] ) {
+						$requested = sanitize_key( (string) $input['post_type'] );
+						$public    = get_post_types( array( 'public' => true ), 'names' );
+
+						if ( ! in_array( $requested, $public, true ) ) {
+							return new WP_Error(
+								'random_page_redirect_invalid_post_type',
+								__( 'The requested post type is not a registered, public post type.', 'random-page-redirect-for-wordpress' ),
+								array( 'status' => 400 )
+							);
+						}
+
+						$post_types = array( $requested );
+					}
+
+					return array(
+						'items' => thisismyurl_random_redirect_get_random_urls( $count, $post_types ),
+					);
+				},
+				'permission_callback' => static function (): bool {
+					// Returns only published, publicly-viewable content. 'read'
+					// is the conservative floor; the same posts are reachable
+					// anonymously via the /random endpoint.
+					return current_user_can( 'read' );
+				},
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => false, // Random selection: repeat calls may differ.
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+);

--- a/random-page-redirect-for-wordpress.php
+++ b/random-page-redirect-for-wordpress.php
@@ -3,7 +3,7 @@
  * Plugin Name:       This Is My URL - Random Page Redirect for WordPress
  * Plugin URI:        https://thisismyurl.com/plugins/random-page-redirect-for-wordpress/
  * Description:       Adds a /random URL that 302s to a random published post. Filterable post types, no-store cache headers, no settings screen.
- * Version:           1.6147
+ * Version:           1.6148.2110
  * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            Christopher Ross

--- a/random-page-redirect-for-wordpress.php
+++ b/random-page-redirect-for-wordpress.php
@@ -51,7 +51,14 @@ add_filter( 'query_vars', 'thisismyurl_random_redirect_query_vars' );
  * Applies the `thisismyurl_random_redirect_post_types` filter, sanitizes the
  * result, and falls back to `[ 'post' ]` when the filter yields nothing usable.
  *
- * @return string[] List of eligible post-type slugs (never empty).
+ * A public-visibility floor is enforced *after* the filter so a third-party
+ * filter callback can never opt a private or non-publicly-queryable type into
+ * the random pool — the /random redirect is an anonymous, publicly reachable
+ * URL. This mirrors the Abilities API execute_callback, which validates the
+ * requested type against `get_post_types( [ 'public' => true ] )`; both paths
+ * now share one public-type guard.
+ *
+ * @return string[] List of eligible public post-type slugs (never empty).
  */
 function thisismyurl_random_redirect_post_types() {
 	/**
@@ -61,6 +68,9 @@ function thisismyurl_random_redirect_post_types() {
 	 */
 	$post_types = apply_filters( 'thisismyurl_random_redirect_post_types', array( 'post' ) );
 	$post_types = array_values( array_filter( array_map( 'sanitize_key', (array) $post_types ) ) );
+
+	$public     = get_post_types( array( 'public' => true ), 'names' );
+	$post_types = array_values( array_intersect( $post_types, $public ) );
 
 	if ( empty( $post_types ) ) {
 		$post_types = array( 'post' );

--- a/random-page-redirect-for-wordpress.php
+++ b/random-page-redirect-for-wordpress.php
@@ -19,6 +19,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/abilities.php';
+
 /**
  * Register the /random rewrite rule and its query var.
  *
@@ -44,6 +46,82 @@ function thisismyurl_random_redirect_query_vars( $vars ) {
 add_filter( 'query_vars', 'thisismyurl_random_redirect_query_vars' );
 
 /**
+ * Resolve the post types eligible for the random pick.
+ *
+ * Applies the `thisismyurl_random_redirect_post_types` filter, sanitizes the
+ * result, and falls back to `[ 'post' ]` when the filter yields nothing usable.
+ *
+ * @return string[] List of eligible post-type slugs (never empty).
+ */
+function thisismyurl_random_redirect_post_types() {
+	/**
+	 * Filters the post types eligible for the /random redirect.
+	 *
+	 * @param string[] $post_types Defaults to [ 'post' ].
+	 */
+	$post_types = apply_filters( 'thisismyurl_random_redirect_post_types', array( 'post' ) );
+	$post_types = array_values( array_filter( array_map( 'sanitize_key', (array) $post_types ) ) );
+
+	if ( empty( $post_types ) ) {
+		$post_types = array( 'post' );
+	}
+
+	return $post_types;
+}
+
+/**
+ * Pick one or more random published posts and return their permalinks.
+ *
+ * The shared selection path for both the /random redirect handler and the
+ * Abilities API endpoint. Queries only published, non-password-protected posts
+ * of the eligible types, ordered randomly, and resolves each to a permalink.
+ *
+ * @param int           $count      How many random URLs to return. Clamped to 1+. Default 1.
+ * @param string[]|null $post_types Eligible post-type slugs. Null resolves via the filter.
+ * @return array<int, array{id:int, url:string}> Random {id, url} pairs; empty when nothing matches.
+ */
+function thisismyurl_random_redirect_get_random_urls( $count = 1, $post_types = null ) {
+	$count      = max( 1, (int) $count );
+	$post_types = null === $post_types ? thisismyurl_random_redirect_post_types() : $post_types;
+
+	$ids = get_posts(
+		array(
+			'post_type'              => $post_types,
+			'post_status'            => 'publish',
+			'has_password'           => false,
+			'ignore_sticky_posts'    => true,
+			'posts_per_page'         => $count,
+			'orderby'                => 'rand',
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'suppress_filters'       => false,
+		)
+	);
+
+	if ( empty( $ids ) ) {
+		return array();
+	}
+
+	$items = array();
+	foreach ( $ids as $id ) {
+		$permalink = get_permalink( (int) $id );
+
+		if ( false === $permalink ) {
+			continue;
+		}
+
+		$items[] = array(
+			'id'  => (int) $id,
+			'url' => $permalink,
+		);
+	}
+
+	return $items;
+}
+
+/**
  * On a /random hit, look up a random published post and 302 to it.
  *
  * Sends Cache-Control: no-store so edges/CDNs don't pin the redirect to a single
@@ -59,43 +137,13 @@ function thisismyurl_random_redirect_handle() {
 		return;
 	}
 
-	/**
-	 * Filters the post types eligible for the /random redirect.
-	 *
-	 * @param string[] $post_types Defaults to [ 'post' ].
-	 */
-	$post_types = apply_filters( 'thisismyurl_random_redirect_post_types', array( 'post' ) );
-	$post_types = array_values( array_filter( array_map( 'sanitize_key', (array) $post_types ) ) );
+	$items = thisismyurl_random_redirect_get_random_urls( 1 );
 
-	if ( empty( $post_types ) ) {
-		$post_types = array( 'post' );
-	}
-
-	$ids = get_posts(
-		array(
-			'post_type'              => $post_types,
-			'post_status'            => 'publish',
-			'has_password'           => false,
-			'ignore_sticky_posts'    => true,
-			'posts_per_page'         => 1,
-			'orderby'                => 'rand',
-			'fields'                 => 'ids',
-			'no_found_rows'          => true,
-			'update_post_meta_cache' => false,
-			'update_post_term_cache' => false,
-			'suppress_filters'       => false,
-		)
-	);
-
-	if ( empty( $ids ) ) {
+	if ( empty( $items ) ) {
 		return;
 	}
 
-	$permalink = get_permalink( (int) $ids[0] );
-
-	if ( false === $permalink ) {
-		return;
-	}
+	$permalink = $items[0]['url'];
 
 	nocache_headers();
 	// nocache_headers() does not emit `no-store`; required to keep CDNs from pinning the redirect.

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,10 @@ Yes. The plugin sends `Cache-Control: no-store, no-cache, must-revalidate, max-a
 
 == Changelog ==
 
+= 1.6148 =
+* Added WordPress 7.0 Abilities API support: the `random-page-redirect/get-random-url` ability returns one or more random published posts as {id, url} pairs for REST/AI discovery (read-only; never performs the redirect).
+* Extracted the random-post selection into a shared `thisismyurl_random_redirect_get_random_urls()` function used by both the /random endpoint and the new ability.
+
 = 1.6147 =
 * Unified plugin versioning to the x.Yddd calendar-version scheme.
 * Confirmed compatibility with WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: random, redirect, discovery
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.6149
+Stable tag: 1.6148.2110
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: random, redirect, discovery
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.6147
+Stable tag: 1.6149
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ The destination is intentionally different on every hit. A 301 would let browser
 Yes. The plugin sends `Cache-Control: no-store, no-cache, must-revalidate, max-age=0` plus `nocache_headers()` so well-behaved edges treat the redirect as uncacheable.
 
 == Changelog ==
+
+= 1.6149 =
+* Security (visibility parity): the /random redirect now enforces the same public-post-type floor as the Abilities API endpoint. A `thisismyurl_random_redirect_post_types` filter callback can no longer opt a private or non-public type into the anonymous redirect pool.
 
 = 1.6148 =
 * Added WordPress 7.0 Abilities API support: the `random-page-redirect/get-random-url` ability returns one or more random published posts as {id, url} pairs for REST/AI discovery (read-only; never performs the redirect).


### PR DESCRIPTION
WP 7 hardening pass — random-page-redirect-for-wordpress.

Recommendation: **QUICK** (contained fixes — quick activation check then merge + tag).

Changes (3 commits):
- Add WP 7 Abilities API support
- Fix P2 /random visibility parity + P3 version/changelog drift
- Stamp release version 1.6148.2110

Audit + scorecard: clients/thisismyurl/plugin-line-hardening/HARDENING-AUDIT.md
All files php -l clean. Version stamped X.6148.2110 (Toronto).